### PR TITLE
Add TSSymbolsBuilderVisitor

### DIFF
--- a/src/TreeSitter-Spec/TSSymbolExplorerPreesenter.class.st
+++ b/src/TreeSitter-Spec/TSSymbolExplorerPreesenter.class.st
@@ -1,0 +1,65 @@
+"
+I am a presenter used by `TSSymbolExplorerPresenter` to display its result in the inspector.
+"
+Class {
+	#name : 'TSSymbolExplorerPreesenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'symbolDictionary',
+		'symbolList',
+		'parentsList',
+		'childrenList'
+	],
+	#category : 'TreeSitter-Spec',
+	#package : 'TreeSitter-Spec'
+}
+
+{ #category : 'initialization' }
+TSSymbolExplorerPreesenter >> connectPresenters [
+
+	super connectPresenters.
+
+	symbolList whenSelectionChangedDo: [ :selection |
+			| parents |
+			parents := Set new.
+			symbolDictionary keysAndValuesDo: [ :symbol :children | (children includes: symbol) ifTrue: [ parents add: symbol ] ].
+			childrenList items: (symbolDictionary at: selection selectedItem) asOrderedCollection.
+			parentsList items: parents asOrderedCollection ].
+
+	symbolList selectFirst
+]
+
+{ #category : 'layout' }
+TSSymbolExplorerPreesenter >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		  spacing: 3;
+		  add: (SpBoxLayout newTopToBottom
+				   add: 'Symbols' expand: false;
+				   add: symbolList);
+		  add: (SpBoxLayout newTopToBottom
+				   add: 'Possible children' expand: false;
+				   add: childrenList);
+		  add: (SpBoxLayout newTopToBottom
+				   add: 'Possible parents' expand: false;
+				   add: parentsList);
+		  yourself
+]
+
+{ #category : 'initialization' }
+TSSymbolExplorerPreesenter >> initializePresenters [
+
+	super initializePresenters.
+
+	symbolList := self newList.
+	childrenList := self newList.
+	parentsList := self newList.
+
+	symbolList items: symbolDictionary keys
+]
+
+{ #category : 'accessing - model' }
+TSSymbolExplorerPreesenter >> setModelBeforeInitialization: aDictionary [
+
+	symbolDictionary := aDictionary
+]

--- a/src/TreeSitter-Spec/TSSymbolExplorerPresenter.class.st
+++ b/src/TreeSitter-Spec/TSSymbolExplorerPresenter.class.st
@@ -2,7 +2,7 @@
 I am a presenter used by `TSSymbolExplorerPresenter` to display its result in the inspector.
 "
 Class {
-	#name : 'TSSymbolExplorerPreesenter',
+	#name : 'TSSymbolExplorerPresenter',
 	#superclass : 'SpPresenter',
 	#instVars : [
 		'symbolDictionary',
@@ -15,7 +15,7 @@ Class {
 }
 
 { #category : 'initialization' }
-TSSymbolExplorerPreesenter >> connectPresenters [
+TSSymbolExplorerPresenter >> connectPresenters [
 
 	super connectPresenters.
 
@@ -30,7 +30,7 @@ TSSymbolExplorerPreesenter >> connectPresenters [
 ]
 
 { #category : 'layout' }
-TSSymbolExplorerPreesenter >> defaultLayout [
+TSSymbolExplorerPresenter >> defaultLayout [
 
 	^ SpBoxLayout newLeftToRight
 		  spacing: 3;
@@ -47,7 +47,7 @@ TSSymbolExplorerPreesenter >> defaultLayout [
 ]
 
 { #category : 'initialization' }
-TSSymbolExplorerPreesenter >> initializePresenters [
+TSSymbolExplorerPresenter >> initializePresenters [
 
 	super initializePresenters.
 
@@ -59,7 +59,7 @@ TSSymbolExplorerPreesenter >> initializePresenters [
 ]
 
 { #category : 'accessing - model' }
-TSSymbolExplorerPreesenter >> setModelBeforeInitialization: aDictionary [
+TSSymbolExplorerPresenter >> setModelBeforeInitialization: aDictionary [
 
 	symbolDictionary := aDictionary
 ]

--- a/src/TreeSitter-Spec/TSSymbolsBuilderVisitor.class.st
+++ b/src/TreeSitter-Spec/TSSymbolsBuilderVisitor.class.st
@@ -85,7 +85,7 @@ TSSymbolsBuilderVisitor >> language: anObject [
 TSSymbolsBuilderVisitor >> symbolsInspector: aBuilder [
 
 	<inspectorPresentationOrder: 50 title: 'Symbols explorer'>
-	^ aBuilder instantiate: TSSymbolExplorerPreesenter on: symbolDictionary
+	^ aBuilder instantiate: TSSymbolExplorerPresenter on: symbolDictionary
 ]
 
 { #category : 'visiting' }

--- a/src/TreeSitter-Spec/TSSymbolsBuilderVisitor.class.st
+++ b/src/TreeSitter-Spec/TSSymbolsBuilderVisitor.class.st
@@ -1,0 +1,96 @@
+"
+I am a little visitor used to see all the symbols present in a project and explore their children and parents.
+
+You can use me like this: 
+
+```st
+	folder := FamixPythonBridge parsingExamples / 'project1'.
+
+	TSSymbolsBuilderVisitor language: TSLanguage python extensions: #( 'py' ) buildOn: folder
+```
+"
+Class {
+	#name : 'TSSymbolsBuilderVisitor',
+	#superclass : 'TSVisitor',
+	#instVars : [
+		'language',
+		'extensions',
+		'filesToParse',
+		'symbolDictionary'
+	],
+	#category : 'TreeSitter-Spec',
+	#package : 'TreeSitter-Spec'
+}
+
+{ #category : 'instance creation' }
+TSSymbolsBuilderVisitor class >> language: aTSLanguage extensions: aCollection buildOn: aFileReference [
+
+	^ self new
+		  language: aTSLanguage;
+		  extensions: aCollection;
+		  buildOn: aFileReference
+]
+
+{ #category : 'building - menus' }
+TSSymbolsBuilderVisitor >> buildOn: aFileReference [
+
+	self collectFilesIn: aFileReference.
+
+	filesToParse
+		do: [ :file | ((TSParser language: self language) parseString: file contents) rootNode accept: self ]
+		displayingProgress: [ :file | file pathString ].
+		
+	self inspect
+]
+
+{ #category : 'initialization' }
+TSSymbolsBuilderVisitor >> collectFilesIn: aFileReference [
+
+	^ aFileReference isFile
+		  ifTrue: [ (self extensions includes: aFileReference extension) ifTrue: [ filesToParse add: aFileReference ] ]
+		  ifFalse: [ aFileReference children do: [ :child | self collectFilesIn: child ] ]
+]
+
+{ #category : 'accessing' }
+TSSymbolsBuilderVisitor >> extensions [
+	^ extensions
+]
+
+{ #category : 'accessing' }
+TSSymbolsBuilderVisitor >> extensions: anObject [
+	extensions := anObject
+]
+
+{ #category : 'initialization' }
+TSSymbolsBuilderVisitor >> initialize [
+
+	super initialize.
+	filesToParse := OrderedCollection new.
+	symbolDictionary := Dictionary new
+]
+
+{ #category : 'accessing' }
+TSSymbolsBuilderVisitor >> language [
+
+	^ language
+]
+
+{ #category : 'accessing' }
+TSSymbolsBuilderVisitor >> language: anObject [
+
+	language := anObject
+]
+
+{ #category : 'as yet unclassified' }
+TSSymbolsBuilderVisitor >> symbolsInspector: aBuilder [
+
+	<inspectorPresentationOrder: 50 title: 'Symbols explorer'>
+	^ aBuilder instantiate: TSSymbolExplorerPreesenter on: symbolDictionary
+]
+
+{ #category : 'visiting' }
+TSSymbolsBuilderVisitor >> visitNode: aTSNode [
+
+	aTSNode collectNamedChild do: [ :subNode | (symbolDictionary at: aTSNode type ifAbsentPut: [ Set new ]) add: subNode type ].
+	super visitNode: aTSNode
+]

--- a/src/TreeSitter/TSParser.class.st
+++ b/src/TreeSitter/TSParser.class.st
@@ -24,6 +24,14 @@ Class {
 }
 
 { #category : 'instance creation' }
+TSParser class >> language: aLanguage [
+
+	^ self new
+		  language: aLanguage;
+		  yourself
+]
+
+{ #category : 'instance creation' }
 TSParser class >> new [
 	
 	TSLibraries new ensureTreeSitterLibraryExists.


### PR DESCRIPTION
This visitor can be configured with a language, extensions to parse and a folder. It will return an inspection of all the symbols present in the resulting trees and will link them to their possible children and possible parents.

Example: 

<img width="1797" height="950" alt="image" src="https://github.com/user-attachments/assets/d0c27a6f-0e39-4766-95df-1c731dd80270" />
