### PR TITLE
Some improvements to the FAST generator

### DIFF
--- a/src/TreeSitter-FAST-Utils/String.extension.st
+++ b/src/TreeSitter-FAST-Utils/String.extension.st
@@ -13,3 +13,11 @@ String >> pascalized [
         ]
     ]
 ]
+
+{ #category : '*TreeSitter-FAST-Utils' }
+String >> pharoLiteralCompatible [
+
+	^ (Symbol reservedLiterals includes: self)
+		  ifTrue: [ self , 'Class' ]
+		  ifFalse: [ self ]
+]

--- a/src/TreeSitter-FAST-Utils/TSFASTBuilder.class.st
+++ b/src/TreeSitter-FAST-Utils/TSFASTBuilder.class.st
@@ -30,7 +30,7 @@ TSFASTBuilder >> addDefineClassIn: metamodelGeneratorClass [
 						          type ifNotEmpty: [
 								          stream
 									          << '	';
-									          << type uncapitalized;
+									          << type uncapitalized pharoLiteralCompatible;
 									          << ' := '.
 								          stream << 'builder ensureClassNamed: #' << type pascalized << '.' ] ]
 				          separatedBy: [
@@ -144,7 +144,7 @@ TSFASTBuilder >> createMetamodelGeneratorClass [
 
 	self typesRefied: ((self typesRefied , types) removeDuplicates reject: [ :each | each isEmpty ]).
 
-	classBuilder slots: self typesRefied.
+	classBuilder slots: (self typesRefied collect: #pharoLiteralCompatible).
 	classBuilder package: #FAST , '-' , self languageName , #'-Model-Generator'.
 	^ classBuilder install
 ]
@@ -199,14 +199,8 @@ TSFASTBuilder >> typesRefied [
 
 { #category : 'accessing' }
 TSFASTBuilder >> typesRefied: aCollection [
-	"Those types will be used to generate some variables. We need to alias the types that have the same name as variables in Pharo."
 
-	| reserved |
-	reserved := Symbol reservedLiterals.
-	typesRefied := aCollection collect: [ :type |
-			               (reserved includes: type)
-				               ifTrue: [ type , 'Class' ]
-				               ifFalse: [ type ] ]
+	typesRefied := aCollection
 ]
 
 { #category : 'building' }


### PR DESCRIPTION
- Clean some code
- Add a missing super call
- Sort entities to have first entity and ERROR and then other types sorted alphabetically
- Do not clash with Pharo reserved literals (such as self, true, false, nil) by adding a "Class" suffix to the type name if needed
