### PR TITLE
Improve the TSFASTImporter

### DIFF
--- a/src/TreeSitter-FAST-Utils/TSFASTImporter.class.st
+++ b/src/TreeSitter-FAST-Utils/TSFASTImporter.class.st
@@ -1,14 +1,24 @@
+"
+I am a generic importer for a FAST model.
+
+I will create all the nodes and relations of the FAST model taking a root node as parameter. 
+
+I will do an exact match to the Tree Sitter AST but I have a subclass that can allow to tweak the model to generate.
+
+Implementation details:
+- The context contains the stack of all elements ""parent"" to the node that is currently been visited. 
+- The #currentFMProperty can either be nil or a FMProperty. If it is a property, it means that the nodes been visited are part of a field of their parent that has the same name as a contained entities property of the fast entity. Thus we save it to save the children in this property instead of the generic one.
+- #containedEntitiesPropertiesMap will save for each kind of FAST class the possible children properties for perf reasons.
+"
 Class {
 	#name : 'TSFASTImporter',
 	#superclass : 'TSVisitor',
 	#instVars : [
-		'tsLanguage',
 		'classesPrefix',
 		'model',
 		'originString',
 		'containedEntitiesPropertiesMap',
 		'context',
-		'currentField',
 		'currentFMProperty'
 	],
 	#category : 'TreeSitter-FAST-Utils',
@@ -22,7 +32,7 @@ TSFASTImporter >> classesPrefix [
 ]
 
 { #category : 'private' }
-TSFASTImporter >> containedEntitiePropertiesFor: aClass [
+TSFASTImporter >> containedEntitiesPropertiesFor: aClass [
 	"I am a cache to know for a FAST class the list of Fame properties they have to define a contained entity."
 
 	^ containedEntitiesPropertiesMap at: aClass ifAbsentPut: [ aClass mooseDescription allProperties select: #isChildrenProperty ]
@@ -31,10 +41,8 @@ TSFASTImporter >> containedEntitiePropertiesFor: aClass [
 { #category : 'actions' }
 TSFASTImporter >> import: aTSNode [
 
-	| rootFastEntity |
 	model := self newInstanceOfClassNamed: self classesPrefix , 'Model'.
-	rootFastEntity := aTSNode accept: self.
-	rootFastEntity source: self originString.
+	aTSNode accept: self.
 	^ model
 ]
 
@@ -85,26 +93,24 @@ TSFASTImporter >> originString: anObject [
 ]
 
 { #category : 'accessing' }
-TSFASTImporter >> tsLanguage [
-
-	^ tsLanguage
-]
-
-{ #category : 'accessing' }
 TSFASTImporter >> tsLanguage: anObject [
 
-	tsLanguage := anObject
+	self deprecated: 'This is not used and can be removed.' t
 ]
 
 { #category : 'visiting' }
 TSFASTImporter >> visitChildren: aTSNode in: fastEntity [
 	"Now we will visit the children after adding myself as the top context so that they can find their parent."
 
+	| previousProperty |
 	context push: fastEntity.
+	
+	"When visiting the children of the children we might lose the current property so we save it."
+	previousProperty := currentFMProperty.
 	
 	aTSNode collectFieldNameOfNamedChild keysAndValuesDo: [ :field :nodes |
 			"If the field has the name of a property, we save this property so that my children can use it to set themselves in the right variable"
-			(self containedEntitiePropertiesFor: fastEntity class)
+			(self containedEntitiesPropertiesFor: fastEntity class)
 				detect: [ :property | property name = field ]
 				ifFound: [ :property | currentFMProperty := property ].
 
@@ -112,7 +118,8 @@ TSFASTImporter >> visitChildren: aTSNode in: fastEntity [
 			nodes isCollection ifTrue: [ nodes do: [ :node | node accept: self ] ] ifFalse: [ nodes accept: self ].
 				
 			currentFMProperty := nil ].
-		
+
+	currentFMProperty := previousProperty.
 	context pop
 ]
 
@@ -122,8 +129,11 @@ TSFASTImporter >> visitNode: aTSNode [
 	| fastEntity |
 	fastEntity := self instantiateFastEntityFrom: aTSNode.
 	
-	"If the context is not empty, I'll set the newly built fast entity to the top of the context."
-	context ifNotEmpty: [
+	"If the context is not empty, I'll set the newly built fast entity to the top of the context.
+	If it is empty this is the root node and we set its source."
+	context
+		ifEmpty: [ fastEntity source: self originString. ]
+		ifNotEmpty: [
 			"I have two way to set myself in my parent:
 				- EIther my parent have a children property of the same name as the field the node belongs to and we set it there. This is the case if the current property is not nil
 				- Else I add the entity to the generic children."


### PR DESCRIPTION
Here is a brief analysis I have:

Currently, children can be created in two places:
- In TSFASTImporter>>#instantiateFastEntityFrom:. This is done if the parent has a method with the same name as the field containing the child.
- In #visitNode: and this is done all the time. It attempts to put it in a variable that has the name of the field, and if that fails, it puts it in #genericChildren.

I see several problems with this:
- Sometimes we have two FAST entities for the same child, since we do it in two places.
- It does not handle the fact that a field is associated with either a node or a collection of nodes.
- It doesn't handle checking whether the Fast variable is an FMOne or FMMany.

This PR does some cleaning and fixed the problems above.

Cleanings:
- Factorize the code to get a fast class name a little
- Use the same way to build the name than the FASTBuilder
- Remove TSLanguage that is not used anymore (I deprecated the setter)
- I now set the source code to the root node before visiting its children and I set the positions while creating the FAST entity in order to be able to have the source code tabs while debugging the import

Children management:
- Now it is not the entity we visit that set their children, it is the children that set themselves in the parent. This allows to simplify some things and will allow to implement in an easier way the custom importers I'll do in a future PR
- Instead of managing children in two places, now it is only in one place. This will avoid duplicated entities as we had before
- Now we do not check the selectors of the Fast entity to know if we have a property of the same name than a field. Instead we check the Fame properties.
- Now we manage the difference between FMOne and FMMany properties

I hope this breaks nothing and only solves bugs :)