### PR TITLE
Fix bug introduced in the TSFASTImporter

### DIFF
--- a/src/TreeSitter-FAST-Utils/TSFASTImporter.class.st
+++ b/src/TreeSitter-FAST-Utils/TSFASTImporter.class.st
@@ -95,7 +95,7 @@ TSFASTImporter >> originString: anObject [
 { #category : 'accessing' }
 TSFASTImporter >> tsLanguage: anObject [
 
-	self deprecated: 'This is not used and can be removed.' t
+	self deprecated: 'This is not used and can be removed.'
 ]
 
 { #category : 'visiting' }
@@ -107,6 +107,7 @@ TSFASTImporter >> visitChildren: aTSNode in: fastEntity [
 	
 	"When visiting the children of the children we might lose the current property so we save it."
 	previousProperty := currentFMProperty.
+	currentFMProperty := nil.
 	
 	aTSNode collectFieldNameOfNamedChild keysAndValuesDo: [ :field :nodes |
 			"If the field has the name of a property, we save this property so that my children can use it to set themselves in the right variable"


### PR DESCRIPTION
I forgot to nil out a variable :( 

My PR introducing the customizable importer will change the code with the error to have something cleaner by refying the context entries. The bug was already fixed without me knowing in my other branch :)

Fixes #34 