### PR TITLE
Use non deprecated API 

### DIFF
--- a/src/TreeSitter-FAST-Utils/TSFASTImporterTestGenerator.class.st
+++ b/src/TreeSitter-FAST-Utils/TSFASTImporterTestGenerator.class.st
@@ -64,7 +64,7 @@ TSFASTImporterTestGenerator >> generateAssertionsFor: entity pushing: pushString
 	| propertiesToAssert |
 	indentation := indentation + 1.
 
-	propertiesToAssert := entity mooseDescription allProperties select: [ :property | self shouldSelectProperty: property of: entity ]. "Sorting properties in order to always have the same order."
+	propertiesToAssert := entity allDeclaredProperties select: [ :property | self shouldSelectProperty: property of: entity ]. "Sorting properties in order to always have the same order."
 	propertiesToAssert sort: #name ascending.
 
 	stream

--- a/src/TreeSitter-FAST-Utils/TSFASTVisitor.class.st
+++ b/src/TreeSitter-FAST-Utils/TSFASTVisitor.class.st
@@ -125,7 +125,7 @@ TSFASTVisitor >> classesPrefix [
 TSFASTVisitor >> containedEntitiesPropertiesFor: aClass [
 	"I am a cache to know for a FAST class the list of Fame properties they have to define a contained entity."
 
-	^ containedEntitiesPropertiesMap at: aClass ifAbsentPut: [ aClass mooseDescription allProperties select: #isChildrenProperty ]
+	^ containedEntitiesPropertiesMap at: aClass ifAbsentPut: [ aClass allDeclaredProperties select: #isChildrenProperty ]
 ]
 
 { #category : 'utilities' }

--- a/src/TreeSitter-FAST-Utils/TSFASTVisitor.class.st
+++ b/src/TreeSitter-FAST-Utils/TSFASTVisitor.class.st
@@ -125,7 +125,11 @@ TSFASTVisitor >> classesPrefix [
 TSFASTVisitor >> containedEntitiesPropertiesFor: aClass [
 	"I am a cache to know for a FAST class the list of Fame properties they have to define a contained entity."
 
-	^ containedEntitiesPropertiesMap at: aClass ifAbsentPut: [ aClass allDeclaredProperties select: #isChildrenProperty ]
+	^ containedEntitiesPropertiesMap at: aClass ifAbsentPut: [
+			  | properties |
+			  "This it here for Moose 12 compatibility. When the support will be drop we can remove the onErrorDo:"
+			  properties := [ aClass metadescription allProperties ] onErrorDo: [ aClass mooseDescription allProperties ].
+			  properties select: #isChildrenProperty ]
 ]
 
 { #category : 'utilities' }


### PR DESCRIPTION
In moose 13 #mooseDescription got renamed to #metadescription. But here I'm replacing a usage by another method present in both Moose 12 and 13 to avoid all problems and a second usage by a try/catch to avoid a compatibility hell 