### PR TITLE
Modifying tests related to symbols so they work on CI and locally disregarding the machine OS type/the version of tree sitter that s loaded

### DIFF
--- a/src/TreeSitter-Tests/TSLanguageCSSTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguageCSSTest.class.st
@@ -28,12 +28,14 @@ TSLanguageCSSTest >> tearDown [
 
 { #category : 'tests' }
 TSLanguageCSSTest >> testCollectAllSymbolOfOneSymbolType [
-
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size
-		equals: 82
+	
+	|symbols|
+	
+	symbols := 	parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+	
+	self assert: symbols isNotEmpty .
+	self assert: symbols size > 80.
+		 
 ]
 
 { #category : 'tests' }
@@ -51,5 +53,5 @@ TSLanguageCSSTest >> testRetrieveSymbolType [
 { #category : 'tests' }
 TSLanguageCSSTest >> testTypescriptNumberOfSymbol [
 
-	self assert: parser language symbolCount equals: 151
+	self assert: parser language symbolCount > 150
 ]

--- a/src/TreeSitter-Tests/TSLanguageCTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguageCTest.class.st
@@ -30,18 +30,21 @@ TSLanguageCTest >> tearDown [
 { #category : 'running' }
 TSLanguageCTest >> testCNumberOfSymbol [
 
-	self assert: parser language symbolCount equals: 363
+	self assert: parser language symbolCount > 360
 ]
 
 { #category : 'running' }
 TSLanguageCTest >> testCollectAllSymbolOfOneSymbolType [
 
-	self skip. "the size depends on the system we compiled the grammar, on Mac it's 160, on linux (in the CI) it's 161"
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size
-		equals: 160
+	 "self skip. " 
+	"the size depends on the system we compiled the grammar, on Mac it's 160, on linux (in the CI) it's 161"
+	
+	|symbols|
+	
+	symbols := parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+	
+	self assert: symbols isNotEmpty.
+	self assert: symbols size > 150
 ]
 
 { #category : 'running' }

--- a/src/TreeSitter-Tests/TSLanguageHTMLTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguageHTMLTest.class.st
@@ -29,11 +29,12 @@ TSLanguageHTMLTest >> tearDown [
 { #category : 'tests' }
 TSLanguageHTMLTest >> testCollectAllSymbolOfOneSymbolType [
 
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size
-		equals: 26
+	|symbols|
+	
+	symbols := parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+	
+	self assert: symbols isNotEmpty .
+	self assert: symbols size > 25
 ]
 
 { #category : 'tests' }
@@ -51,5 +52,5 @@ TSLanguageHTMLTest >> testRetrieveSymbolType [
 { #category : 'tests' }
 TSLanguageHTMLTest >> testTypescriptNumberOfSymbol [
 
-	self assert: parser language symbolCount equals: 41
+	self assert: parser language symbolCount > 40
 ]

--- a/src/TreeSitter-Tests/TSLanguagePythonTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguagePythonTest.class.st
@@ -29,17 +29,18 @@ TSLanguagePythonTest >> tearDown [
 { #category : 'tests' }
 TSLanguagePythonTest >> testCollectAllSymbolOfOneSymbolType [
 
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size
-		equals: 129
+	|symbols|
+	
+	symbols := parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+
+	self assert: symbols isNotEmpty.
+	self assert: symbols size > 125
 ]
 
 { #category : 'tests' }
 TSLanguagePythonTest >> testPythonNumberOfSymbol [
 
-	self assert: parser language symbolCount equals: 274
+	self assert: parser language symbolCount > 270
 ]
 
 { #category : 'tests' }

--- a/src/TreeSitter-Tests/TSLanguageTypescriptTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguageTypescriptTest.class.st
@@ -29,11 +29,12 @@ TSLanguageTypescriptTest >> tearDown [
 { #category : 'tests' }
 TSLanguageTypescriptTest >> testCollectAllSymbolOfOneSymbolType [
 
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size
-		equals: 192
+	|symbols|
+	
+	symbols := parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+
+	self assert: symbols isNotEmpty.
+	self assert: symbols size > 190
 ]
 
 { #category : 'tests' }
@@ -51,5 +52,5 @@ TSLanguageTypescriptTest >> testRetrieveSymbolType [
 { #category : 'tests' }
 TSLanguageTypescriptTest >> testTypescriptNumberOfSymbol [
 
-	self assert: parser language symbolCount equals: 383
+	self assert: parser language symbolCount > 380
 ]

--- a/src/TreeSitter-Tests/TSLanguageXMLTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguageXMLTest.class.st
@@ -29,11 +29,12 @@ TSLanguageXMLTest >> tearDown [
 { #category : 'tests' }
 TSLanguageXMLTest >> testCollectAllSymbolOfOneSymbolType [
 
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size
-		equals: 54
+	|symbols|
+	
+	symbols := parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+
+	self assert: symbols isNotEmpty.
+	self assert: symbols size > 50
 ]
 
 { #category : 'tests' }
@@ -51,5 +52,5 @@ TSLanguageXMLTest >> testRetrieveSymbolType [
 { #category : 'tests' }
 TSLanguageXMLTest >> testTypescriptNumberOfSymbol [
 
-	self assert: parser language symbolCount equals: 143
+	self assert: parser language symbolCount > 140
 ]

--- a/src/TreeSitter-Tests/TSLanguageYAMLTest.class.st
+++ b/src/TreeSitter-Tests/TSLanguageYAMLTest.class.st
@@ -29,10 +29,12 @@ TSLanguageYAMLTest >> tearDown [
 { #category : 'tests' }
 TSLanguageYAMLTest >> testCollectAllSymbolOfOneSymbolType [
  
-	self
-		assert:
-		(parser language symbolsOfType: TSSymbolType tssymboltyperegular)
-			size > 1
+	|symbols|
+
+	symbols := parser language symbolsOfType: TSSymbolType tssymboltyperegular.
+
+	self assert: symbols isNotEmpty. 
+	self assert: symbols size > 150
 
 ]
 


### PR DESCRIPTION
I think this is the best way to test because nobody garanties that the symbols count remains the same when new versions of original tree sitter are pushed