### PR TITLE
Improve loading

### DIFF
--- a/src/BaselineOfTreeSitter/BaselineOfTreeSitter.class.st
+++ b/src/BaselineOfTreeSitter/BaselineOfTreeSitter.class.st
@@ -34,36 +34,18 @@ BaselineOfTreeSitter >> defineGroups: spec [
 
 	spec
 		group: 'default'
-		with:
-			#( 'TreeSitter' 'TreeSitter-Tests' 'TreeSitter-Spec'
-			   'TreeSitter-Highlighter' 'TreeSitter-Visitor'
-			   'TreeSitter-FAST-Utils' 'TreeSitter-Libraries'
-			   'TreeSitter-Typescript' 'TreeSitter-Typescript-Tests' ).
+		with: #( 'TreeSitter' 'TreeSitter-Tests' 'TreeSitter-Spec' 'TreeSitter-Highlighter' 'TreeSitter-Visitor' 'TreeSitter-Libraries' 'TreeSitter-Typescript'
+			   'TreeSitter-Typescript-Tests' ).
 
 	spec group: 'moose' with: #( 'default' 'TreeSitter-FAST-Utils' ).
 
-	spec
-		group: 'xml'
-		with: #( 'default' 'TreeSitter-XML' 'TreeSitter-XML-Tests' ).
-	spec
-		group: 'python'
-		with: #( 'default' 'TreeSitter-Python' 'TreeSitter-Python-Tests' ). 
-	spec
-		group: 'yaml'
-		with: #( 'default' 'TreeSitter-YAML' 'TreeSitter-YAML-Tests' ).
-	spec
-		group: 'html'
-		with: #( 'default' 'TreeSitter-HTML' 'TreeSitter-HTML-Tests' ).
-	spec
-		group: 'css'
-		with: #( 'default' 'TreeSitter-CSS' 'TreeSitter-CSS-Tests' ).
-	spec
-		group: 'typescript'
-		with:
-		#( 'default' 'TreeSitter-Typescript' 'TreeSitter-Typescript-Tests' ).
-	spec
-		group: 'cLang'
-		with: #( 'default' 'TreeSitter-C' 'TreeSitter-C-Tests' ).
+	spec group: 'xml' with: #( 'default' 'TreeSitter-XML' 'TreeSitter-XML-Tests' ).
+	spec group: 'python' with: #( 'default' 'TreeSitter-Python' 'TreeSitter-Python-Tests' ).
+	spec group: 'yaml' with: #( 'default' 'TreeSitter-YAML' 'TreeSitter-YAML-Tests' ).
+	spec group: 'html' with: #( 'default' 'TreeSitter-HTML' 'TreeSitter-HTML-Tests' ).
+	spec group: 'css' with: #( 'default' 'TreeSitter-CSS' 'TreeSitter-CSS-Tests' ).
+	spec group: 'typescript' with: #( 'default' 'TreeSitter-Typescript' 'TreeSitter-Typescript-Tests' ).
+	spec group: 'cLang' with: #( 'default' 'TreeSitter-C' 'TreeSitter-C-Tests' ).
 	spec group: 'groovy' with: #( 'default' 'TreeSitter-Groovy' 'TreeSitter-Groovy-Tests' ).
 	spec group: 'mermaid' with: #( 'default' 'TreeSitter-Mermaid' 'TreeSitter-Mermaid-Tests' )
 ]

--- a/src/TreeSitter-FAST-Utils/Object.extension.st
+++ b/src/TreeSitter-FAST-Utils/Object.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'MooseEntity' }
+Extension { #name : 'Object' }
 
 { #category : '*TreeSitter-FAST-Utils' }
-MooseEntity >> addGenericChild: anObject [
+Object >> addGenericChild: anObject [
 	"This is just for compatibility during the time we regenerate all FAST models based on TreeSitter. To remove later."
 
 	self deprecated: 'The Metamodel needs to be regenerated in order to generate the right #addGenericChild: method on the fast entities.'.


### PR DESCRIPTION
- Do not load TreeSitter-FAST-Utils by default
- Fix undeclared warnings by pushing a deprecated method from MooseEntity that is not declared as dependency to Object (This is a deprecated method that will be removed so it should be ok)